### PR TITLE
add prev and next button to emotion details

### DIFF
--- a/components/EmotionDetail.js
+++ b/components/EmotionDetail.js
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import styled from "styled-components";
 
 const StyledArticle = styled.article`
@@ -33,6 +34,22 @@ const StyledListItem = styled.li`
   border-radius: 5px;
 `;
 
+const StyledLink = styled(Link)`
+  font-size: 50px;
+  text-decoration: none;
+  color: black;
+  position: fixed;
+  margin: 1rem;
+  top: 50%;
+`;
+const PrevLink = styled(StyledLink)`
+  left: 0;
+`;
+
+const NextLink = styled(StyledLink)`
+  right: 0;
+`;
+
 export default function EmotionDetails({
   name,
   description,
@@ -40,6 +57,8 @@ export default function EmotionDetails({
   indications,
   subemotions,
   color,
+  prevEmotion,
+  nextEmotion,
 }) {
   return (
     <StyledArticle $color={color}>
@@ -55,6 +74,8 @@ export default function EmotionDetails({
           <StyledListItem key={sub}>{sub}</StyledListItem>
         ))}
       </StyledList>
+      <PrevLink href={`/emotions/${prevEmotion.slug}`}>↞</PrevLink>
+      <NextLink href={`/emotions/${nextEmotion.slug}`}>↠</NextLink>
     </StyledArticle>
   );
 }

--- a/pages/emotions/[slug]/index.js
+++ b/pages/emotions/[slug]/index.js
@@ -22,6 +22,15 @@ export default function EmotionDetailsPage() {
   }
   const { slug } = router.query;
   const emotion = emotionData.find((emotion) => emotion.slug === slug);
+  const emotionIndex = emotionData.findIndex(
+    (emotion) => emotion.slug === slug
+  );
+
+  let prevEmotion = emotionData[emotionIndex - 1];
+  emotionIndex === 0 ? (prevEmotion = emotionData[6]) : prevEmotion;
+  let nextEmotion = emotionData[emotionIndex + 1];
+  emotionIndex === 6 ? (nextEmotion = emotionData[0]) : nextEmotion;
+
   if (!emotion) return <h1>emotion not found</h1>;
   return (
     <>
@@ -32,6 +41,8 @@ export default function EmotionDetailsPage() {
         indications={emotion.indications}
         subemotions={emotion.subemotions}
         color={emotion.color}
+        prevEmotion={prevEmotion}
+        nextEmotion={nextEmotion}
       />
       <StyledLink $color={emotion.color} href="/emotions">
         ← back to list{" "}

--- a/pages/emotions/[slug]/index.js
+++ b/pages/emotions/[slug]/index.js
@@ -26,10 +26,12 @@ export default function EmotionDetailsPage() {
     (emotion) => emotion.slug === slug
   );
 
-  let prevEmotion = emotionData[emotionIndex - 1];
-  emotionIndex === 0 ? (prevEmotion = emotionData[6]) : prevEmotion;
-  let nextEmotion = emotionData[emotionIndex + 1];
-  emotionIndex === 6 ? (nextEmotion = emotionData[0]) : nextEmotion;
+  const prevEmotionIndex =
+    emotionIndex === 0 ? emotionData.length - 1 : emotionIndex - 1;
+  const prevEmotion = emotionData[prevEmotionIndex];
+  const nextEmotionIndex =
+    emotionIndex === emotionData.length - 1 ? 0 : emotionIndex + 1;
+  const nextEmotion = emotionData[nextEmotionIndex];
 
   if (!emotion) return <h1>emotion not found</h1>;
   return (


### PR DESCRIPTION
https://github.com/users/janaRicarda/projects/1/views/1?pane=issue&itemId=60430558

Add a previous button and next button to emotion details, to navigate easily through the seven basic emotions details.