### PR TITLE
bugfix/entry-flow

### DIFF
--- a/components/EmotionForm.js
+++ b/components/EmotionForm.js
@@ -94,7 +94,7 @@ const ToggleSwitch = styled(Circle)`
 
 export default function EmotionForm({
   theme,
-  slug,
+  emotion,
   editMode,
   onSubmit,
   id,
@@ -105,7 +105,6 @@ export default function EmotionForm({
 
   const {
     timeStamp,
-    emotion,
     tensionLevel,
     subemotion,
     intensity,
@@ -114,24 +113,24 @@ export default function EmotionForm({
     notes,
   } = correspondingEntry;
 
+  // in order to preset inputField values (e.g. line: 258) correctly, the emotionValue (line: 128) needs to be upperCase
+  const emotionUpperCase = emotion.charAt(0).toUpperCase() + emotion.slice(1);
+
   const [formValues, setFormValues] = useState(() => {
-    const inCaseOfNoEmotion = {
-      color: "lightgray",
-      subemotions: [],
-    };
-    const { color, subemotions } = emotion
-      ? emotionData.find((emotionObject) => emotionObject.name === emotion)
-      : inCaseOfNoEmotion;
+    const { subemotions } = emotion
+      ? emotionData.find((emotionObject) => emotionObject.slug === emotion)
+      : { subemotions: [] };
+      
     return {
       tensionValue: tensionLevel,
-      emotionValue: emotion,
+      emotionValue: emotionUpperCase,
       selectedSubemotionValue: subemotion,
       intensityValue: intensity ? intensity : "0",
       categoryValue: category ? category : "50",
       triggerValue: trigger,
       notesValue: notes,
       subemotionOptions: subemotions,
-      colorValue: color,
+      colorValue: emotion ? `var(--${emotion})` : "lightgray",
     };
   });
 
@@ -400,7 +399,9 @@ export default function EmotionForm({
       ></StyledTextarea>
       <StyledSubmitButton
         type="submit"
-        $submit={theme === darkTheme ? `var(--${slug})` : `var(--text-on-dark)`}
+        $submit={
+          theme === darkTheme ? `var(--${emotion})` : `var(--text-on-dark)`
+        }
         $submitBackground={
           theme === darkTheme ? `black` : `var(--text-on-bright)`
         }

--- a/components/EmotionList.js
+++ b/components/EmotionList.js
@@ -115,17 +115,13 @@ const EmotionLink = styled(StyledStandardLink)`
   }
 `;
 
-export default function EmotionList({ createMode, id, onAddEmotionDetails }) {
+export default function EmotionList({ createMode, id }) {
   const [rotation, setRotation] = useState(0);
   const [touchStart, setTouchStart] = useState(null);
   const [isDragging, setIsDragging] = useState(false);
 
   if (!emotionData) {
     return <h1>Sorry, an error has occured. Please try again later!</h1>;
-  }
-  function handleAddDetails(data, id) {
-    const emotion = { emotion: data };
-    onAddEmotionDetails(emotion, id);
   }
 
   function handleScroll(event) {

--- a/components/EmotionList.js
+++ b/components/EmotionList.js
@@ -175,7 +175,6 @@ export default function EmotionList({ createMode, id, onAddEmotionDetails }) {
         >
           {emotionData.map(({ slug, name }) => (
             <StyledListItem
-              onClick={createMode && (() => handleAddDetails(name, id))}
               $color={`var(--${slug})`}
               key={slug}
             >
@@ -184,7 +183,10 @@ export default function EmotionList({ createMode, id, onAddEmotionDetails }) {
                 slug={slug}
                 href={
                   createMode
-                    ? { pathname: `/create/${slug}`, query: { id } }
+                    ? {
+                        pathname: `/create/${slug}`,
+                        query: { id },
+                      }
                     : `/emotions/${slug}`
                 }
               >

--- a/components/EmotionRecordsList.js
+++ b/components/EmotionRecordsList.js
@@ -256,7 +256,13 @@ export default function EmotionRecordsList({
                             editFromDevControls
                               ? router.push(`edit/${id}`)
                               : router.push(
-                                  `./edit/${useExampleData ? id : _id}`
+                                  {
+                                    pathname: `./edit/${
+                                      useExampleData ? id : _id
+                                    }`,
+                                    query: { emotion: emotion },
+                                  },
+                                  `edit/${useExampleData ? id : _id}`
                                 )
                           }
                         />

--- a/components/Manual.js
+++ b/components/Manual.js
@@ -148,8 +148,6 @@ export default function Manual() {
   function handleManualScroll(id) {
     setTimeout(() => {
       const element = document.getElementById(id);
-      console.log(id);
-      console.log("handlemanualscroll");
       element.scrollIntoView({ behavior: "smooth" });
     }, 100);
   }

--- a/pages/add-entry.js
+++ b/pages/add-entry.js
@@ -163,7 +163,6 @@ export default function HomePage({
                     pathname: "/create",
                     query: { id: useExampleData ? id : newestDbEntryID },
                   }}
-                  forwardedAs={`/create`}
                 >
                   Add more details
                 </StyledAddDetailsLink>

--- a/pages/create/[slug]/index.js
+++ b/pages/create/[slug]/index.js
@@ -47,7 +47,7 @@ export default function EmotionEntry({
         <title>Record your emotion</title>
       </Head>
       <EmotionForm
-        slug={slug}
+        emotion={slug}
         theme={theme}
         onSubmit={onAddEmotionDetails}
         correspondingEntry={correspondingEntry}

--- a/pages/create/index.js
+++ b/pages/create/index.js
@@ -8,7 +8,6 @@ import {
 import Head from "next/head";
 
 export default function CreateIndexPage({
-  onAddEmotionDetails,
   handleToolTip,
 }) {
   const router = useRouter();
@@ -30,7 +29,6 @@ export default function CreateIndexPage({
         <EmotionList
           createMode
           id={id}
-          onAddEmotionDetails={onAddEmotionDetails}
         />
       </StyledEmotionListWrapper>
     </>

--- a/pages/edit/[id]/index.js
+++ b/pages/edit/[id]/index.js
@@ -13,7 +13,8 @@ export default function EditPage({
 }) {
   const router = useRouter();
 
-  const { id } = router.query;
+  const { id, emotion } = router.query;
+
   useEffect(() => {
     handleToolTip({
       text: "  Refine your emotion entry with the editing form. Adjust your initial selection by switching the emotion if necessary, selecting a subemotion, and updating the intensity of your emotion on a scale from 0 to 100. Re-classify the emotion as unpleasant, neutral, or pleasant, and optionally revise any triggers or notes to further enrich your emotional record.",
@@ -26,12 +27,15 @@ export default function EditPage({
 
   if (!correspondingEntry) return <h2>Page not found!</h2>;
 
+  const emotionToLowerCase = emotion.toLowerCase();
+
   return (
     <>
       <Head>
         <title>Edit</title>
       </Head>
       <EmotionForm
+        emotion={emotionToLowerCase}
         theme={theme}
         locale={locale}
         onSubmit={onAddEmotionDetails}


### PR DESCRIPTION
the bug:

- following the entry flow there were two things happening AT THE SAME TIME when clicking an emotion in the `EmotionList` (wheel):
  - there was a function on every `listItem`(of the wheel) executing a POST method via the `handleAddEmotionDetails` function in `app.js` AND
  - forwarding the user to the `create` route where `EmotionForm` is rendered
  
- having those two things happening at the same time is a problem because: 
- on `create` route  the newest entry was fetched via the `_id` 
- now sometimes the problem occured that the POST method was not fast enough before the GET method could fetch the newly and just added emotion details
- resulted in grey color and not correct heading on `EmotionForm`

The Solution: 
- i deleted the POST method when clicking listItems on the emotion Wheel
- and replaced it with putting the clicked emotion to the query of the URL 
- the `EmotionForm` receives its information from the URL information instead of the mongoDB to ensure this data is always up to date for the `create` path
- now the mongoDB gets fully updated when submitting the `EmotionForm` and not before

- the `EmotionForm` logic was updated to work 
- was adjusted and tested in `edit` path as well